### PR TITLE
Remove duplicate check for ModelState validity

### DIFF
--- a/grid/odata-v4-web-api-binding-wrappers/KendoUIMVC5/Controllers/ProductsController.cs
+++ b/grid/odata-v4-web-api-binding-wrappers/KendoUIMVC5/Controllers/ProductsController.cs
@@ -43,11 +43,6 @@ namespace KendoUIMVC5.Controllers
                 return BadRequest(ModelState);
             }
 
-            if (!ModelState.IsValid)
-            {
-                return BadRequest(ModelState);
-            }
-
             if (key != product.ProductID)
             {
                 return BadRequest();


### PR DESCRIPTION
Two other minor questions:

- Why not move the check for whether the product exists to before attaching and saving? Would also remove the need for the `try/catch` around `SaveChanges()`.
- Use `Any()` instead of `Count()` in the `ProductExists` method.