### PR TITLE
Update Edit mode in combobox with grid editinline

### DIFF
--- a/grid/grid-foreign-key-combo-box-column/GridForeignKeyComboBoxColumn/GridForeignKeyComboBoxColumn.csproj
+++ b/grid/grid-foreign-key-combo-box-column/GridForeignKeyComboBoxColumn/GridForeignKeyComboBoxColumn.csproj
@@ -174,6 +174,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Global.asax" />
+    <Content Include="Scripts\Views\Home\index.js" />
     <Content Include="Web.config" />
     <Content Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>

--- a/grid/grid-foreign-key-combo-box-column/GridForeignKeyComboBoxColumn/Scripts/Views/Home/index.js
+++ b/grid/grid-foreign-key-combo-box-column/GridForeignKeyComboBoxColumn/Scripts/Views/Home/index.js
@@ -1,0 +1,11 @@
+﻿function changeEditInline(e) {
+    if (e.model.isNew() === false) {
+        
+        var kendoComboBoxEmployee = $("#EmployeeId").data("kendoComboBox");
+
+        if (kendoComboBoxEmployee.select() === 0) {
+            kendoComboBoxEmployee.select(-1);
+            kendoComboBoxEmployee.select(0);
+        }        
+    }
+}

--- a/grid/grid-foreign-key-combo-box-column/GridForeignKeyComboBoxColumn/Views/Home/Index.cshtml
+++ b/grid/grid-foreign-key-combo-box-column/GridForeignKeyComboBoxColumn/Views/Home/Index.cshtml
@@ -31,4 +31,7 @@
         .Read(read => read.Action("ForeignKeyColumn_Read", "Home"))
         .Update(update => update.Action("ForeignKeyColumn_Update", "Home"))
     )
+    .Events( ev => ev.Edit("changeEditInline") )
 )
+
+<script src="~/Scripts/Views/Home/index.js"></script>


### PR DESCRIPTION
Corrected when you change to edit mode and the first element in the combobox was selected (in this case was lost the select item), you need to change firstly to -1 and select to 0 again for correct it.
